### PR TITLE
fix(lru): Fix use of undefined variables

### DIFF
--- a/src/draw/sdl/lv_draw_sdl_texture_cache.c
+++ b/src/draw/sdl/lv_draw_sdl_texture_cache.c
@@ -102,7 +102,7 @@ void lv_draw_sdl_texture_cache_put_advanced(lv_draw_sdl_ctx_t * ctx, const void 
     }
     if(flags & LV_DRAW_SDL_CACHE_FLAG_MANAGED) {
         /* Managed texture doesn't count into cache size */
-        LV_LOG_INFO("cache texture %p, %d*%d@%dbpp", texture, width, height, SDL_BITSPERPIXEL(format));
+        LV_LOG_INFO("cache texture %p", texture);
         lv_lru_set(lru, key, key_length, value, 1);
         return;
     }


### PR DESCRIPTION
### Description of the feature or fix

Compiling with LV_LOG_LEVEL_INFO or higher when using SDL render backend result in a compilation error due to undefined use of width, height and  format variables:

`lv_draw_sdl_texture_cache.c:105:63: error: 'width' undeclared (first use in this function)
LV_LOG_INFO("cache texture %p, %d*%d@%dbpp", texture, width, height, SDL_BITSPERPIXEL(format));`

`lv_draw_sdl_texture_cache.c:105:70: error: 'height' undeclared (first use in this function)
LV_LOG_INFO("cache texture %p, %d*%d@%dbpp", texture, width, height, SDL_BITSPERPIXEL(format));`

`lv_draw_sdl_texture_cache.c:105:95: error: 'format' undeclared (first use in this function)
LV_LOG_INFO("cache texture %p, %d*%d@%dbpp", texture, width, height, SDL_BITSPERPIXEL(format));`

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation



